### PR TITLE
Spike: Index page filters

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,7 +6,7 @@ const markdownItAnchor = require('markdown-it-anchor');
 const {
   getSlugMap,
   getSortedCollection,
-  // getTagList
+  getTagList,
   indexItems,
 } = require('./src/_11ty/collections');
 const {
@@ -53,6 +53,7 @@ module.exports = function (eleventyConfig) {
   );
   eleventyConfig.addCollection('entriesMap', collectionApi => getSlugMap(collectionApi, 'entries'));
   eleventyConfig.addCollection('indexItems', indexItems);
+  eleventyConfig.addCollection('tagList', getTagList);
 
   /**
    * Add custom filters

--- a/src/_11ty/collections/getTagList.js
+++ b/src/_11ty/collections/getTagList.js
@@ -8,12 +8,9 @@ module.exports = collection => {
         switch (item) {
           // this list should match the `filter` list in tags.njk
           case 'all':
-          case 'nav':
-          case 'project':
-          case 'projects':
-          case 'solutions':
-          case 'team':
-          case 'technologies':
+          case 'entries':
+          case 'collections':
+          case 'series':
             return false;
         }
 

--- a/src/_data/difficultyLevels.js
+++ b/src/_data/difficultyLevels.js
@@ -1,0 +1,8 @@
+/**
+ * Map to these using an integer 1 - 4 in frontmatter.
+ * Describing content as "advanced" level would be done like so:
+ *
+ * level: 3
+ */
+
+module.exports = ['basic', 'intermediate', 'advanced', 'master'];

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -3,8 +3,6 @@ class IndexFilters {
     this.container = document.querySelector('.index .js-filter');
     this.checkboxFilters = Array.from(this.container.querySelectorAll('input[type="checkbox"]'));
     this.selectFilters = Array.from(this.container.querySelectorAll('select'));
-    this.indexListContainer = document.querySelector('.index .js-index-list');
-    this.indexList = Array.from(this.indexListContainer.querySelectorAll('[data-tags]'));
     this.clearButton = this.container.querySelector('.clear');
 
     this.filterState = {};
@@ -48,7 +46,8 @@ class IndexFilters {
 
   updateIndexListItems(tagsToShow) {
     // For each index item, check if it matches the filter(s)
-    this.indexList.forEach(indexItem => {
+    // Have to select all every time we filter in case the user has made a search
+    Array.from(document.querySelectorAll('[data-tags]')).forEach(indexItem => {
       const itemTags = indexItem.dataset.tags.split(',');
       const shouldFilter = tagsToShow.every(tag => itemTags.includes(tag));
       indexItem.classList.toggle('hide', !shouldFilter);
@@ -66,7 +65,10 @@ class IndexFilters {
       [...filter.options].forEach(option => (this.filterState[option.value] = false));
     });
 
-    this.indexList.forEach(item => item.classList.remove('hide'));
+    // Have to select all every time we filter in case the user has made a search
+    Array.from(document.querySelectorAll('[data-tags]')).forEach(item =>
+      item.classList.remove('hide'),
+    );
   }
 }
 

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -1,0 +1,45 @@
+class IndexFilters {
+  constructor() {
+    this.container = document.querySelector('.index .js-filter');
+    this.filters = Array.from(this.container.querySelectorAll('input[type="checkbox"]'));
+    this.indexListContainer = document.querySelector('.index .js-index-list');
+    this.indexList = Array.from(this.indexListContainer.querySelectorAll('[data-tags]'));
+    this.clearButton = this.container.querySelector('.clear');
+
+    this.filterState = {};
+
+    this.init();
+  }
+
+  init() {
+    this.filters.forEach(filter => {
+      this.filterState[filter.value] = false;
+      filter.addEventListener('change', e => this.onCheckboxChange(e));
+    });
+
+    this.clearButton.addEventListener('click', () => this.onClearButtonClick());
+  }
+
+  onCheckboxChange(e) {
+    const { value, checked } = e.target;
+    this.filterState[value] = checked;
+    const tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
+
+    // For each index item, check if it matches the filter(s)
+    this.indexList.forEach(indexItem => {
+      const itemTags = indexItem.dataset.tags.split(',');
+      const shouldFilter = itemTags.some(tag => tagsToShow.includes(tag));
+      indexItem.classList.toggle('hide', !shouldFilter);
+    });
+  }
+
+  onClearButtonClick() {
+    this.filters.forEach(filter => {
+      filter.checked = false;
+      this.filterState[filter.value] = false;
+    });
+    this.indexList.forEach(item => item.classList.remove('hide'));
+  }
+}
+
+export default IndexFilters;

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -5,7 +5,13 @@ class IndexFilters {
     this.selectFilters = Array.from(this.container.querySelectorAll('select'));
     this.clearButton = this.container.querySelector('.clear');
 
+    this.indexItems = Array.from(document.querySelectorAll('[data-tags]'));
+
+    this.searchInput = document.querySelector('.js-search-input');
+
     this.filterState = {};
+
+    this.tagsToShow = [];
 
     this.init();
   }
@@ -20,15 +26,20 @@ class IndexFilters {
       filter.addEventListener('change', e => this.onSelectChange(e));
     });
 
+    this.searchInput.addEventListener('input', () => {
+      this.indexItems = Array.from(document.querySelectorAll('[data-tags]'));
+      this.updateIndexListItems();
+    });
+
     this.clearButton.addEventListener('click', () => this.onClearButtonClick());
   }
 
   onCheckboxChange(e) {
     const { value, checked } = e.target;
     this.filterState[value] = checked;
-    const tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
+    this.tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
 
-    this.updateIndexListItems(tagsToShow);
+    this.updateIndexListItems();
   }
 
   onSelectChange(e) {
@@ -39,17 +50,17 @@ class IndexFilters {
       this.filterState[value] = true;
     }
 
-    const tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
+    this.tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
 
-    this.updateIndexListItems(tagsToShow);
+    this.updateIndexListItems();
   }
 
-  updateIndexListItems(tagsToShow) {
+  updateIndexListItems() {
     // For each index item, check if it matches the filter(s)
     // Have to select all every time we filter in case the user has made a search
-    Array.from(document.querySelectorAll('[data-tags]')).forEach(indexItem => {
+    this.indexItems.forEach(indexItem => {
       const itemTags = indexItem.dataset.tags.split(',');
-      const shouldFilter = tagsToShow.every(tag => itemTags.includes(tag));
+      const shouldFilter = this.tagsToShow.every(tag => itemTags.includes(tag));
       indexItem.classList.toggle('hide', !shouldFilter);
     });
   }
@@ -66,9 +77,7 @@ class IndexFilters {
     });
 
     // Have to select all every time we filter in case the user has made a search
-    Array.from(document.querySelectorAll('[data-tags]')).forEach(item =>
-      item.classList.remove('hide'),
-    );
+    this.indexItems.forEach(item => item.classList.remove('hide'));
   }
 }
 

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -1,9 +1,9 @@
 class IndexFilters {
   constructor() {
-    this.container = document.querySelector('.index .js-filter');
+    this.container = document.querySelector('.index .js-filter-bar');
     this.checkboxFilters = Array.from(this.container.querySelectorAll('input[type="checkbox"]'));
     this.selectFilters = Array.from(this.container.querySelectorAll('select'));
-    this.clearButton = this.container.querySelector('.clear');
+    this.clearButton = this.container.querySelector('.js-clear-button');
 
     this.indexItems = Array.from(document.querySelectorAll('[data-tags]'));
 

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -1,7 +1,8 @@
 class IndexFilters {
   constructor() {
     this.container = document.querySelector('.index .js-filter');
-    this.filters = Array.from(this.container.querySelectorAll('input[type="checkbox"]'));
+    this.checkboxFilters = Array.from(this.container.querySelectorAll('input[type="checkbox"]'));
+    this.selectFilters = Array.from(this.container.querySelectorAll('select'));
     this.indexListContainer = document.querySelector('.index .js-index-list');
     this.indexList = Array.from(this.indexListContainer.querySelectorAll('[data-tags]'));
     this.clearButton = this.container.querySelector('.clear');
@@ -12,9 +13,13 @@ class IndexFilters {
   }
 
   init() {
-    this.filters.forEach(filter => {
+    this.checkboxFilters.forEach(filter => {
       this.filterState[filter.value] = false;
       filter.addEventListener('change', e => this.onCheckboxChange(e));
+    });
+
+    this.selectFilters.forEach(filter => {
+      filter.addEventListener('change', e => this.onSelectChange(e));
     });
 
     this.clearButton.addEventListener('click', () => this.onClearButtonClick());
@@ -25,6 +30,23 @@ class IndexFilters {
     this.filterState[value] = checked;
     const tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
 
+    this.updateIndexListItems(tagsToShow);
+  }
+
+  onSelectChange(e) {
+    const { value, options } = e.target;
+    [...options].forEach(option => (this.filterState[option.value] = false));
+
+    if (value !== 'js-clear') {
+      this.filterState[value] = true;
+    }
+
+    const tagsToShow = Object.keys(this.filterState).filter(key => this.filterState[key] === true);
+
+    this.updateIndexListItems(tagsToShow);
+  }
+
+  updateIndexListItems(tagsToShow) {
     // For each index item, check if it matches the filter(s)
     this.indexList.forEach(indexItem => {
       const itemTags = indexItem.dataset.tags.split(',');
@@ -34,10 +56,16 @@ class IndexFilters {
   }
 
   onClearButtonClick() {
-    this.filters.forEach(filter => {
+    this.checkboxFilters.forEach(filter => {
       filter.checked = false;
       this.filterState[filter.value] = false;
     });
+
+    this.selectFilters.forEach(filter => {
+      filter.value = 'js-clear';
+      [...filter.options].forEach(option => (this.filterState[option.value] = false));
+    });
+
     this.indexList.forEach(item => item.classList.remove('hide'));
   }
 }

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -59,7 +59,7 @@ class IndexFilters {
     // For each index item, check if it matches the filter(s)
     // Have to select all every time we filter in case the user has made a search
     this.indexItems.forEach(indexItem => {
-      const itemTags = indexItem.dataset.tags.split(',');
+      const itemTags = [...indexItem.dataset.tags.split(','), indexItem.dataset.level];
       const shouldFilter = this.tagsToShow.every(tag => itemTags.includes(tag));
       indexItem.classList.toggle('hide', !shouldFilter);
     });

--- a/src/assets/scripts/IndexFilters.js
+++ b/src/assets/scripts/IndexFilters.js
@@ -28,7 +28,7 @@ class IndexFilters {
     // For each index item, check if it matches the filter(s)
     this.indexList.forEach(indexItem => {
       const itemTags = indexItem.dataset.tags.split(',');
-      const shouldFilter = itemTags.some(tag => tagsToShow.includes(tag));
+      const shouldFilter = tagsToShow.every(tag => itemTags.includes(tag));
       indexItem.classList.toggle('hide', !shouldFilter);
     });
   }

--- a/src/assets/scripts/SearchBar.js
+++ b/src/assets/scripts/SearchBar.js
@@ -206,13 +206,16 @@ class SearchBar {
     }
 
     results.forEach(result => {
-      const { title, url, entries } = result.item;
+      const { title, url, entries, tags } = result.item;
+
+      const resultWrapper = document.createElement('div');
+      resultWrapper.setAttribute('data-tags', tags);
 
       const resultLabel = document.createElement('dt');
       const resultType = this.search.getResultType(result.item);
       resultLabel.classList.add('index__type');
       resultLabel.textContent = resultType;
-      this.searchResults.appendChild(resultLabel);
+      resultWrapper.appendChild(resultLabel);
 
       const resultDesc = document.createElement('dd');
       resultDesc.classList.add('as-h1', 'index__desc');
@@ -231,7 +234,7 @@ class SearchBar {
         `.trim();
 
         resultDesc.appendChild(entryLink);
-        this.searchResults.appendChild(resultDesc);
+        resultWrapper.appendChild(resultDesc);
       } else {
         // Input
         const expandInput = document.createElement('input');
@@ -286,8 +289,10 @@ class SearchBar {
 
         resultDesc.appendChild(nestList);
 
-        this.searchResults.appendChild(resultDesc);
+        resultWrapper.appendChild(resultDesc);
       }
+
+      this.searchResults.appendChild(resultWrapper);
     });
   }
 }

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -17,7 +17,7 @@ onDocumentReady(() => {
     new SearchBar(search);
   }
 
-  if (document.querySelector('.index .js-filter')) {
+  if (document.querySelector('.index .js-filter-bar')) {
     new IndexFilters();
   }
 });

--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -4,6 +4,7 @@ import { onDocumentReady } from './utils';
 import ExternalLinks from './ExternalLinks';
 import Search from './Search';
 import SearchBar from './SearchBar';
+import IndexFilters from './IndexFilters';
 // import ThemeToggle from './ThemeToggle';
 
 onDocumentReady(() => {
@@ -14,5 +15,9 @@ onDocumentReady(() => {
 
   if (document.querySelector('.js-search-input')) {
     new SearchBar(search);
+  }
+
+  if (document.querySelector('.index .js-filter')) {
+    new IndexFilters();
   }
 });

--- a/src/assets/styles/base/_global.scss
+++ b/src/assets/styles/base/_global.scss
@@ -116,3 +116,7 @@ hr {
     display: block;
   }
 }
+
+.hide {
+  display: none;
+}

--- a/src/collections/css.md
+++ b/src/collections/css.md
@@ -1,8 +1,9 @@
 ---
 layout: layouts/collection/index.njk
 title: CSS
-date: 2020-10-30
+date: 2020-11-20
 tags:
+  - css
 entries:
   - The Box Model
   - Cascade, Inheritance, & Specificity

--- a/src/entries/cascade-inheritance-and-specificity.md
+++ b/src/entries/cascade-inheritance-and-specificity.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: Cascade, Inheritance, & Specificity
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - css
-  - basic
+level: 1
 ---
 
 # Cascade, Inheritance, & Specificity

--- a/src/entries/css-preprocessing.md
+++ b/src/entries/css-preprocessing.md
@@ -1,9 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: CSS Preprocessing
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - css
+level: 2
 ---
 
 # CSS Preprocessing

--- a/src/entries/html-elements.md
+++ b/src/entries/html-elements.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: HTML Elements
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - html
-  - basic
+level: 1
 ---
 
 # HTML Elements

--- a/src/entries/intro-to-git.md
+++ b/src/entries/intro-to-git.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: Intro to Git
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - git
-  - basic
+level: 1
 ---
 
 # Intro to Git

--- a/src/entries/intro-to-html.md
+++ b/src/entries/intro-to-html.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: Intro to HTML
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - html
-  - basic
+level: 1
 ---
 
 # Intro to HTML

--- a/src/entries/intro-to-terminal.md
+++ b/src/entries/intro-to-terminal.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: Intro to Terminal
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - terminal
-  - basic
+level: 1
 ---
 
 # Intro to Terminal

--- a/src/entries/the-box-model.md
+++ b/src/entries/the-box-model.md
@@ -1,10 +1,10 @@
 ---
 layout: layouts/entry/index.njk
 title: The Box Model
-date: 2020-10-30
+date: 2020-11-20
 tags:
   - css
-  - basic
+level: 1
 ---
 
 # The Box Model

--- a/src/pages/index/_styles.scss
+++ b/src/pages/index/_styles.scss
@@ -56,6 +56,25 @@ $icon-size: 1em;
   }
 }
 
+.filter {
+  background: #cccccc;
+  position: absolute;
+  z-index: 300;
+  width: 300px;
+  top: 0;
+  right: 0;
+
+  label {
+    display: flex;
+    align-items: center;
+
+    input {
+      width: auto;
+      margin-right: 10px;
+    }
+  }
+}
+
 /**
  * Page
  */

--- a/src/pages/index/_styles.scss
+++ b/src/pages/index/_styles.scss
@@ -11,19 +11,22 @@
  */
 $icon-size: 1em;
 
-.search-bar {
-  @include flex;
+.search-and-filter-wrapper {
   @include layer(2);
-  align-items: center;
   background-color: var(--bg-color);
-  border-bottom: 1px solid $black;
-  flex-grow: 0;
-  font-size: $fs2;
-  height: var(--header-height);
   left: var(--gutter-full);
   position: fixed;
   right: 0;
   top: 0;
+}
+
+.search-bar {
+  @include flex;
+  align-items: center;
+  border-bottom: 1px solid $black;
+  flex-grow: 0;
+  font-size: $fs2;
+  height: var(--header-height);
 
   @include mq($sm) {
     font-size: $fs3;
@@ -56,23 +59,53 @@ $icon-size: 1em;
   }
 }
 
+/**
+ * Filter
+ */
+
+.filter-bar {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  padding: $sp-3 var(--gutter-full) $sp0 0;
+}
+
+.filter-heading {
+  &:not(:first-of-type) {
+    margin-left: $sp0;
+  }
+}
+
 .filter {
-  background: #cccccc;
-  position: absolute;
-  z-index: 300;
-  width: 300px;
-  top: 0;
-  right: 0;
+  cursor: pointer;
+  margin: 0 ($sp-1 / 2);
+}
 
-  label {
-    display: flex;
-    align-items: center;
+.filter--topic__list {
+  display: flex;
+}
 
-    input {
-      width: auto;
-      margin-right: 10px;
+.filter--topic__text {
+  display: inline-block;
+
+  &::after {
+    @include size(0.5em);
+    border: 1px solid currentColor;
+    content: '';
+    display: inline-block;
+    margin-left: 0.25em;
+    margin-bottom: 0.1em;
+
+    .filter--topic__label:focus &,
+    .filter--topic__label:hover &,
+    .filter--topic__input:checked + & {
+      background-color: currentColor;
     }
   }
+}
+
+.clear {
+  margin-left: auto;
 }
 
 /**

--- a/src/pages/index/index.njk
+++ b/src/pages/index/index.njk
@@ -51,7 +51,7 @@ templateClass: index
         .data
         .tags[0] %}
 
-      <div data-tags="{{ item.data.tags }}">
+      <div data-tags="{{ item.data.tags }}" data-level="{{ difficultyLevels[item.data.level - 1] }}">
 
         <dt class="index__type">
           {{ "Entry" if tagDef == "entries" }}

--- a/src/pages/index/index.njk
+++ b/src/pages/index/index.njk
@@ -8,10 +8,18 @@ templateClass: index
 <div class="filter js-filter" style="padding: 20px;">
   Filter by
   <ul>
+    <li>
+      <select name="type" id="typeFilter">
+        <option value="js-clear" selected="selected">All</option>
+        <option value="entries">Entries</option>
+        <option value="series">Series</option>
+        <option value="collections">Collections</option>
+      </select>
+    </li>
     {% for tag in collections.tagList %}
       <li>
-        <label for="{{ tag ~ '-filter' }}">
-          <input type="checkbox" name="filter" value="{{ tag }}" id="{{ tag ~ '-filter' }}"/>
+        <label for="{{ tag ~ 'Filter' }}">
+          <input type="checkbox" name="filter" value="{{ tag }}" id="{{ tag ~ 'Filter' }}"/>
           <span>{{ tag }}</span>
         </label>
       </li>

--- a/src/pages/index/index.njk
+++ b/src/pages/index/index.njk
@@ -5,6 +5,22 @@ title: Index
 templateClass: index
 ---
 
+<div class="filter js-filter" style="padding: 20px;">
+  Filter by
+  <ul>
+    {% for tag in collections.tagList %}
+      <li>
+        <label for="">
+          <input type="checkbox" name="filter" value="{{ tag }}" />
+          <span>{{ tag }}</span>
+        </label>
+      </li>
+    {% endfor %}
+  </ul>
+
+  <button class="clear">Clear Filters</button>
+</div>
+
 {# Search #}
 <div class="search-wrapper js-search-wrapper">
   <div class="search-bar">
@@ -26,59 +42,64 @@ templateClass: index
       {% set tagDef = item
         .data
         .tags[0] %}
-      <dt class="index__type">
-        {{ "Entry" if tagDef == "entries" }}
-        {{ "Collection" if tagDef == "collections" }}
-        {{ "Series" if tagDef == "series" }}
-      </dt>
 
-      <dd class="as-h1 index__desc">
-        {% if tagDef == "entries" %}
-          {# Entries #}
-          <a href="{{ item.url }}" class="index__link">
-            <h1 class="index__title">
-              {{ item.data.title }}
-              <svg class="index__icon index__icon--arrow">
-                <use xlink:href="#arrow"></use>
-              </svg>
-            </h1>
-          </a>
+      <div data-tags="{{ item.data.tags }}">
 
-        {% else %}
-          {# Series & Collections #}
-          {% set inputName = "expand-" ~ (item.data.title | slug) %}
-          <input class="index__expand-input" type="checkbox" name="{{ inputName }}" id="{{ inputName }}"/>
-          <label class="index__expand-label" for="{{ inputName }}">
-            <h1 class="index__title">
-              {{ item.data.title }}
-              <svg class="index__icon index__icon--plus">
-                <use xlink:href="#plus"></use>
-              </svg>
-              <svg class="index__icon index__icon--minus">
-                <use xlink:href="#minus"></use>
-              </svg>
-            </h1>
-          </label>
+        <dt class="index__type">
+          {{ "Entry" if tagDef == "entries" }}
+          {{ "Collection" if tagDef == "collections" }}
+          {{ "Series" if tagDef == "series" }}
+        </dt>
 
-          <ol class="index__nest">
-            {% if item.data.entries | length %}
-              {% for entry in item.data.entries %}
-                <li class="index__nest__item">
-                  <a href="{{ '/entries/' ~ entry | slug }}" class="index__link">
-                    <h2 class="index__title">
-                      {{ entry }}
-                      <svg class="index__icon index__icon--arrow">
-                        <use xlink:href="#arrow"></use>
-                      </svg>
-                    </h2>
-                  </a>
-                </li>
-              {% endfor %}
-            {% endif %}
-          </ol>
+        <dd class="as-h1 index__desc">
+          {% if tagDef == "entries" %}
+            {# Entries #}
+            <a href="{{ item.url }}" class="index__link">
+              <h1 class="index__title">
+                {{ item.data.title }}
+                <svg class="index__icon index__icon--arrow">
+                  <use xlink:href="#arrow"></use>
+                </svg>
+              </h1>
+            </a>
 
-        {% endif %}
-      </dd>
+          {% else %}
+            {# Series & Collections #}
+            {% set inputName = "expand-" ~ (item.data.title | slug) %}
+            <input class="index__expand-input" type="checkbox" name="{{ inputName }}" id="{{ inputName }}"/>
+            <label class="index__expand-label" for="{{ inputName }}">
+              <h1 class="index__title">
+                {{ item.data.title }}
+                <svg class="index__icon index__icon--plus">
+                  <use xlink:href="#plus"></use>
+                </svg>
+                <svg class="index__icon index__icon--minus">
+                  <use xlink:href="#minus"></use>
+                </svg>
+              </h1>
+            </label>
+
+            <ol class="index__nest">
+              {% if item.data.entries | length %}
+                {% for entry in item.data.entries %}
+                  <li class="index__nest__item">
+                    <a href="{{ '/entries/' ~ entry | slug }}" class="index__link">
+                      <h2 class="index__title">
+                        {{ entry }}
+                        <svg class="index__icon index__icon--arrow">
+                          <use xlink:href="#arrow"></use>
+                        </svg>
+                      </h2>
+                    </a>
+                  </li>
+                {% endfor %}
+              {% endif %}
+            </ol>
+
+          {% endif %}
+        </dd>
+
+      </div>
     {% endfor %}
   </dl>
 {% endif %}

--- a/src/pages/index/index.njk
+++ b/src/pages/index/index.njk
@@ -10,8 +10,8 @@ templateClass: index
   <ul>
     {% for tag in collections.tagList %}
       <li>
-        <label for="">
-          <input type="checkbox" name="filter" value="{{ tag }}" />
+        <label for="{{ tag ~ '-filter' }}">
+          <input type="checkbox" name="filter" value="{{ tag }}" id="{{ tag ~ '-filter' }}"/>
           <span>{{ tag }}</span>
         </label>
       </li>
@@ -52,6 +52,7 @@ templateClass: index
         </dt>
 
         <dd class="as-h1 index__desc">
+
           {% if tagDef == "entries" %}
             {# Entries #}
             <a href="{{ item.url }}" class="index__link">
@@ -62,7 +63,6 @@ templateClass: index
                 </svg>
               </h1>
             </a>
-
           {% else %}
             {# Series & Collections #}
             {% set inputName = "expand-" ~ (item.data.title | slug) %}
@@ -79,8 +79,8 @@ templateClass: index
               </h1>
             </label>
 
-            <ol class="index__nest">
-              {% if item.data.entries | length %}
+            {% if item.data.entries | length %}
+              <ol class="index__nest">
                 {% for entry in item.data.entries %}
                   <li class="index__nest__item">
                     <a href="{{ '/entries/' ~ entry | slug }}" class="index__link">
@@ -93,13 +93,13 @@ templateClass: index
                     </a>
                   </li>
                 {% endfor %}
-              {% endif %}
-            </ol>
+              </ol>
+            {% endif %}
 
           {% endif %}
         </dd>
-
       </div>
     {% endfor %}
+
   </dl>
 {% endif %}

--- a/src/pages/index/index.njk
+++ b/src/pages/index/index.njk
@@ -5,37 +5,60 @@ title: Index
 templateClass: index
 ---
 
-<div class="filter js-filter" style="padding: 20px;">
-  Filter by
-  <ul>
-    <li>
-      <select name="type" id="typeFilter">
+{# Search #}
+<div class="js-search-wrapper">
+  <div class="search-and-filter-wrapper">
+    <section class="search-bar">
+      <h1 class="hide">
+        Search
+      </h1>
+      <svg class="search-icon">
+        <use xlink:href="#search"></use>
+      </svg>
+      <input class="search-input js-search-input" type="text" placeholder="Search">
+    </section>
+
+    <section class="filter-bar js-filter-bar">
+      <h1 class="hide">
+        Filter
+      </h1>
+
+      <h2 class="filter-heading">
+        Type:
+      </h2>
+      <select class="filter filter--type" name="type" id="typeFilter">
         <option value="js-clear" selected="selected">All</option>
         <option value="entries">Entries</option>
         <option value="series">Series</option>
         <option value="collections">Collections</option>
       </select>
-    </li>
-    {% for tag in collections.tagList %}
-      <li>
-        <label for="{{ tag ~ 'Filter' }}">
-          <input type="checkbox" name="filter" value="{{ tag }}" id="{{ tag ~ 'Filter' }}"/>
-          <span>{{ tag }}</span>
-        </label>
-      </li>
-    {% endfor %}
-  </ul>
 
-  <button class="clear">Clear Filters</button>
-</div>
+      <h2 class="filter-heading">
+        Level:
+      </h2>
+      <select class="filter filter--level" name="type" id="typeFilter">
+        <option value="js-clear" selected="selected">Any</option>
+        {% for level in difficultyLevels %}
+          <option value="{{ level }}">{{ level | capitalize }}</option>
+        {% endfor %}
+      </select>
 
-{# Search #}
-<div class="search-wrapper js-search-wrapper">
-  <div class="search-bar">
-    <svg class="search-icon">
-      <use xlink:href="#search"></use>
-    </svg>
-    <input class="search-input js-search-input" type="text" placeholder="Search">
+      <h2 class="filter-heading">
+        Topic:
+      </h2>
+      <ul class="filter--topic__list">
+        {% for tag in collections.tagList %}
+          <li>
+            <label class="filter filter--topic__label" for="{{ tag ~ 'Filter' }}">
+              <input class="filter--topic__input hide" type="checkbox" name="filter" value="{{ tag }}" id="{{ tag ~ 'Filter' }}"/>
+              <span class="filter--topic__text">{{ tag | upper }}</span>
+            </label>
+          </li>
+        {% endfor %}
+      </ul>
+
+      <button class="clear js-clear-button">Clear Filters</button>
+    </section>
   </div>
 
   <dl class="index__list search-results js-search-results" role="list"></dl>

--- a/src/series/basic-html.md
+++ b/src/series/basic-html.md
@@ -4,7 +4,7 @@ title: Basic HTML
 date: 2020-11-20
 tags:
   - html
-  - basic
+level: 1
 entries:
   - Intro to HTML
   - HTML Elements

--- a/src/series/basic-html.md
+++ b/src/series/basic-html.md
@@ -1,8 +1,10 @@
 ---
 layout: layouts/series/index.njk
 title: Basic HTML
-date: 2020-10-30
+date: 2020-11-20
 tags:
+  - html
+  - basic
 entries:
   - Intro to HTML
   - HTML Elements


### PR DESCRIPTION
## What this does

Closes #16 

Took a stab at filtering index page items by tag... I don't know if there's a better way to do this in eleventy, but I couldn't find any resources on making templates "reactive" with eleventy collections 🤷 

## Steps to test

- Go to the index page
- Check out the super fancy filters
  - Filter by `terminal`. Make sure the entry with the `terminal` tag is shown and the rest are hidden.
  - Uncheck `terminal`. Make sure all item show up again
  - Filter by `terminal` AND `git`. Make sure two corresponding entries show up and the rest are hidden.
  - Hit the `Clear Filters` button and make sure all entries/collections/series show up again

![image](https://user-images.githubusercontent.com/6599979/99117221-5895e100-25c3-11eb-95d4-db265604b1c5.png)


## Open Questions

- Should collections/series be filtered depending on their respective entries? (i.e. should a collection that has an entry tagged with `git` be shown when filtering by `git`?)