### PR TITLE
align baselines of nav print texts

### DIFF
--- a/src/_includes/layouts/entry/_styles.scss
+++ b/src/_includes/layouts/entry/_styles.scss
@@ -255,7 +255,11 @@ a {
     @include layer(1);
     pointer-events: none;
     position: absolute;
-    top: $sp0;
+    top: var(--gutter-half);
+
+    @include mq($md) {
+      top: calc(var(--gutter-half) + 1px);
+    }
   }
 }
 


### PR DESCRIPTION
## Changes

Changes position of "Always be learning" in the entry nav to align its baseline to "Upstatement Public Library"